### PR TITLE
Exclude unnecessary files from package

### DIFF
--- a/EngageEvents.Build
+++ b/EngageEvents.Build
@@ -334,6 +334,8 @@
     <exclude name="**/obj/**"/>
     <exclude name="${referencesDirectory}/**"/>
     <exclude name="packages/**" />
+    <exclude name="**/bin/**"/>
+    <exclude name="CustomDictionary.xml"/>
   </patternset>
   <patternset id="source.fileset">
     <include name="**/*.js"/>
@@ -355,6 +357,7 @@
     <include name="??.??.??.txt" />
     <include name="MSBuild/*.dll"/>
     <include name="MSBuild/*.targets"/>
+    <include name="CustomDictionary.xml"/>
     <exclude name="**/obj/**"/>
     <exclude name="Release.txt" />
   </patternset>


### PR DESCRIPTION
Excluding 'bin' folder and 'CustomDictionary.xml' from Resources.zip in the install package.
